### PR TITLE
release/v0.3.3

### DIFF
--- a/__tests__/utils/command.test.ts
+++ b/__tests__/utils/command.test.ts
@@ -36,7 +36,7 @@ beforeEach(() => {
 });
 const workDir                      = resolve(__dirname, 'test-dir');
 const logger                       = new Logger(string => Utils.replaceAll(string, workDir, '[Working Directory]'));
-const helper                       = new GitHelper(logger, {depth: -1});
+const helper                       = new GitHelper(logger, {depth: -1, token: 'test-token'});
 const setExists                    = testFs();
 const rootDir                      = resolve(__dirname, '..', 'fixtures');
 const octokit                      = new GitHub('');
@@ -80,10 +80,9 @@ describe('clone', () => {
 	testChildProcess();
 
 	it('should run clone command', async() => {
-		process.env.GITHUB_WORKSPACE   = workDir;
-		process.env.INPUT_GITHUB_TOKEN = 'test-token';
-		const mockExec                 = spyOnExec();
-		const mockStdout               = spyOnStdout();
+		process.env.GITHUB_WORKSPACE = workDir;
+		const mockExec               = spyOnExec();
+		const mockStdout             = spyOnStdout();
 
 		await clone(helper, logger, octokit, getActionContext(context({
 			head: {
@@ -122,8 +121,7 @@ describe('checkBranch', () => {
 	testChildProcess();
 
 	it('should do nothing', async() => {
-		process.env.GITHUB_WORKSPACE   = workDir;
-		process.env.INPUT_GITHUB_TOKEN = 'test-token';
+		process.env.GITHUB_WORKSPACE = workDir;
 		setChildProcessParams({stdout: 'hello-world/test-branch'});
 		const mockExec = spyOnExec();
 		setExists(true);
@@ -139,8 +137,7 @@ describe('checkBranch', () => {
 	});
 
 	it('should checkout new branch', async() => {
-		process.env.GITHUB_WORKSPACE   = workDir;
-		process.env.INPUT_GITHUB_TOKEN = 'test-token';
+		process.env.GITHUB_WORKSPACE = workDir;
 		setChildProcessParams({stdout: 'test-branch2'});
 		const mockExec = spyOnExec();
 		setExists(true);
@@ -188,8 +185,7 @@ describe('getChangedFiles', () => {
 	});
 
 	it('should get changed files 1', async() => {
-		process.env.GITHUB_WORKSPACE   = workDir;
-		process.env.INPUT_GITHUB_TOKEN = 'test-token';
+		process.env.GITHUB_WORKSPACE = workDir;
 		setChildProcessParams({stdout: 'M  file1\nA  file2\nD  file3\n   file4\n\nB  file5\n'});
 
 		expect(await getChangedFiles(helper, logger, octokit, getActionContext(_context, {
@@ -213,7 +209,6 @@ describe('getChangedFiles', () => {
 
 	it('should get changed files 2', async() => {
 		process.env.GITHUB_WORKSPACE      = workDir;
-		process.env.INPUT_GITHUB_TOKEN    = 'test-token';
 		process.env.INPUT_PACKAGE_MANAGER = 'yarn';
 		setChildProcessParams({stdout: 'M  file1\nA  file2\nD  file3\n   file4\n\nB  file5\n'});
 
@@ -255,8 +250,7 @@ describe('getChangedFiles', () => {
 	});
 
 	it('should return empty 1', async() => {
-		process.env.GITHUB_WORKSPACE   = workDir;
-		process.env.INPUT_GITHUB_TOKEN = 'test-token';
+		process.env.GITHUB_WORKSPACE = workDir;
 		setChildProcessParams({stdout: 'test'});
 
 		expect(await getChangedFiles(helper, logger, octokit, getActionContext(_context, {
@@ -309,9 +303,8 @@ describe('getChangedFiles', () => {
 	});
 
 	it('should return empty 2', async() => {
-		process.env.GITHUB_WORKSPACE   = workDir;
-		process.env.INPUT_GITHUB_TOKEN = 'test-token';
-		const mockStdout               = spyOnStdout();
+		process.env.GITHUB_WORKSPACE = workDir;
+		const mockStdout             = spyOnStdout();
 		setChildProcessParams({
 			stdout: (command: string): string => {
 				if (command.includes(' rev-parse')) {
@@ -390,10 +383,9 @@ describe('getChangedFiles', () => {
 	});
 
 	it('should return empty 3', async() => {
-		process.env.GITHUB_WORKSPACE   = workDir;
-		process.env.GITHUB_REPOSITORY  = 'hello/world';
-		process.env.INPUT_GITHUB_TOKEN = 'test-token';
-		const mockStdout               = spyOnStdout();
+		process.env.GITHUB_WORKSPACE  = workDir;
+		process.env.GITHUB_REPOSITORY = 'hello/world';
+		const mockStdout              = spyOnStdout();
 		setChildProcessParams({
 			stdout: (command: string): string => {
 				if (command.includes(' rev-parse')) {
@@ -550,8 +542,7 @@ describe('resolveConflicts', () => {
 	testChildProcess();
 
 	it('should merge', async() => {
-		process.env.GITHUB_WORKSPACE   = workDir;
-		process.env.INPUT_GITHUB_TOKEN = 'test-token';
+		process.env.GITHUB_WORKSPACE = workDir;
 		setChildProcessParams({
 			stdout: (command: string): string => {
 				if (command.startsWith('git merge')) {

--- a/__tests__/utils/process1.test.ts
+++ b/__tests__/utils/process1.test.ts
@@ -497,8 +497,9 @@ describe('execute', () => {
 	});
 
 	it('should do nothing (action pull request not found)', async() => {
-		process.env.GITHUB_WORKSPACE = workDir;
-		const mockStdout             = spyOnStdout();
+		process.env.GITHUB_WORKSPACE   = workDir;
+		process.env.INPUT_GITHUB_TOKEN = 'test-token';
+		const mockStdout               = spyOnStdout();
 
 		nock('https://api.github.com')
 			.persist()
@@ -530,8 +531,9 @@ describe('execute', () => {
 	});
 
 	it('should do nothing (not target branch)', async() => {
-		process.env.GITHUB_WORKSPACE = workDir;
-		const mockStdout             = spyOnStdout();
+		process.env.GITHUB_WORKSPACE   = workDir;
+		process.env.INPUT_GITHUB_TOKEN = 'test-token';
+		const mockStdout               = spyOnStdout();
 
 		nock('https://api.github.com')
 			.persist()

--- a/__tests__/utils/variables.test.ts
+++ b/__tests__/utils/variables.test.ts
@@ -30,8 +30,8 @@ beforeEach(() => {
 	Logger.resetForTesting();
 });
 const octokit = new GitHub('');
-const logger = new Logger();
-const helper = new GitHelper(logger, {depth: -1});
+const logger  = new Logger();
+const helper  = new GitHelper(logger, {depth: -1, token: 'test-token'});
 const rootDir = resolve(__dirname, '..', 'fixtures');
 testFs(true);
 
@@ -40,7 +40,7 @@ const actionDetails: ActionDetails = {
 	actionOwner: 'octocat',
 	actionRepo: 'hello-world',
 };
-const getActionContext = (context: Context, _actionDetails?: ActionDetails, defaultBranch?: string, cache?: object, isBatchProcess?: boolean): ActionContext => ({
+const getActionContext             = (context: Context, _actionDetails?: ActionDetails, defaultBranch?: string, cache?: object, isBatchProcess?: boolean): ActionContext => ({
 	actionContext: context,
 	actionDetail: _actionDetails ?? actionDetails,
 	cache: Object.assign(cache ?? {}, {
@@ -48,7 +48,7 @@ const getActionContext = (context: Context, _actionDetails?: ActionDetails, defa
 	}),
 	isBatchProcess,
 });
-const generateActionContext = (
+const generateActionContext        = (
 	settings: {
 		event?: string | undefined;
 		action?: string | undefined;
@@ -69,7 +69,7 @@ const generateActionContext = (
 	cache,
 	isBatchProcess,
 );
-const prPayload = {
+const prPayload                    = {
 	'pull_request': {
 		number: 11,
 		id: 21031067,
@@ -632,7 +632,7 @@ describe('getPrBody', () => {
 	});
 
 	it('should get PR Body for default branch 1', async() => {
-		const prBody = '${ACTION_OWNER}';
+		const prBody                 = '${ACTION_OWNER}';
 		const prBodyForDefaultBranch = '${ACTION_REPO}';
 
 		expect(await getPrBody(false, [], [], helper, logger, octokit, generateActionContext({owner: 'owner', repo: 'repo', event: 'pull_request', ref: 'heads/master'}, {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@actions/core": "^1.2.1",
     "@actions/github": "^2.0.1",
     "@technote-space/filter-github-action": "^0.1.17",
-    "@technote-space/github-action-helper": "^0.8.0",
+    "@technote-space/github-action-helper": "^0.8.1",
     "moment": "^2.24.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   },
   "devDependencies": {
     "@technote-space/github-action-test-helper": "^0.1.4",
-    "@types/jest": "^24.9.0",
-    "@types/node": "^13.1.8",
+    "@types/jest": "^24.9.1",
+    "@types/node": "^13.5.0",
     "@typescript-eslint/eslint-plugin": "^2.17.0",
     "@typescript-eslint/parser": "^2.17.0",
     "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@technote-space/github-action-pr-helper",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "PullRequest Helper for GitHub Actions.",
   "author": "Technote <technote.space@gmail.com> (https://technote.space)",
   "license": "MIT",

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -62,6 +62,7 @@ const getClearPackageCommands = (context: ActionContext): string[] => {
 	if (isDisabledDeletePackage(context)) {
 		return [];
 	}
+
 	return [
 		'rm -f package.json',
 		'rm -f package-lock.json',
@@ -82,6 +83,7 @@ const getGlobalInstallPackagesCommands = (context: ActionContext): string[] => {
 			];
 		}
 	}
+
 	return [];
 };
 
@@ -98,6 +100,7 @@ const getDevInstallPackagesCommands = (context: ActionContext): string[] => {
 			];
 		}
 	}
+
 	return [];
 };
 
@@ -114,6 +117,7 @@ const getInstallPackagesCommands = (context: ActionContext): string[] => {
 			];
 		}
 	}
+
 	return [];
 };
 

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -14,9 +14,11 @@ export const getActionDetail = <T>(key: string, context: ActionContext, defaultV
 	if (undefined === defaultValue && !(key in context.actionDetail)) {
 		throw new Error(`parameter [${key}] is required.`);
 	}
+
 	if (undefined === defaultValue && typeof context.actionDetail[key] === 'string' && context.actionDetail[key].trim() === '') {
 		throw new Error(`parameter [${key}] is required.`);
 	}
+
 	return context.actionDetail[key] || (typeof defaultValue === 'function' ? defaultValue() : undefined);
 };
 
@@ -104,6 +106,7 @@ export const filterGitStatus = (line: string, context: ActionContext): boolean =
 		// language=JSRegexp
 		return (new RegExp(`^[${targets}]\\s+`)).test(line);
 	}
+
 	return true;
 };
 
@@ -113,12 +116,14 @@ export const filterExtension = (line: string, context: ActionContext): boolean =
 		const pattern = '(' + extensions.map(item => escapeRegExp('.' + item.replace(/^\./, ''))).join('|') + ')';
 		return (new RegExp(`${pattern}$`)).test(line);
 	}
+
 	return true;
 };
 
 export const getHelper = (context: ActionContext): GitHelper => new GitHelper(new Logger(replaceDirectory), {
 	depth: -1,
 	filter: (line: string): boolean => filterGitStatus(line, context) && filterExtension(line, context),
+
 });
 
 export const getPullsArgsForDefaultBranch = async(octokit: GitHub, context: ActionContext): Promise<PullsParams> => ({
@@ -174,6 +179,7 @@ export const getCache = async <T>(key: string, generator: () => (T | Promise<T>)
 		// eslint-disable-next-line require-atomic-updates
 		context.cache[key] = await generator();
 	}
+
 	return context.cache[key];
 };
 

--- a/src/utils/variables.ts
+++ b/src/utils/variables.ts
@@ -46,8 +46,10 @@ const contextVariables = async(isComment: boolean, helper: GitHelper, logger: Lo
 			if (branch === await getDefaultBranch(octokit, context)) {
 				return getActionContext(await getPullsArgsForDefaultBranch(octokit, context), octokit, context);
 			}
+
 			return getActionContext(await findPR(branch, logger, octokit, context), octokit, context);
 		}
+
 		return context;
 	};
 
@@ -56,8 +58,10 @@ const contextVariables = async(isComment: boolean, helper: GitHelper, logger: Lo
 		if (!context.actionContext.payload.pull_request) {
 			throw new Error('Invalid context.');
 		}
+
 		return extractor(await ensureGetPulls((await getContext(getContextBranch(context))).actionContext.payload.pull_request, octokit, context));
 	};
+
 	return [
 		{key: 'PR_NUMBER', replace: getPrParamFunc(pr => pr.number)},
 		{key: 'PR_NUMBER_REF', replace: getPrParamFunc(async(pr) => pr.number ? `#${pr.number}` : await getDefaultBranchUrl(octokit, context))},
@@ -92,6 +96,7 @@ const replaceVariables = async(string: string, variables: { key: string; replace
 			replaced = replaceAll(replaced, `\${${variable.key}}`, await variable.replace());
 		}
 	}
+
 	return replaced;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -516,10 +516,10 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.9.0.tgz#78c6991cd1734cf0d390be24875e310bb0a9fb74"
-  integrity sha512-dXvuABY9nM1xgsXlOtLQXJKdacxZJd7AtvLsKZ/0b57ruMXDKCOXAC/M75GbllQX6o1pcZ5hAG4JzYy7Z/wM2w==
+"@types/jest@^24.9.1":
+  version "24.9.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.9.1.tgz#02baf9573c78f1b9974a5f36778b366aa77bd534"
+  integrity sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==
   dependencies:
     jest-diff "^24.3.0"
 
@@ -528,10 +528,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
-"@types/node@>= 8", "@types/node@^13.1.8":
-  version "13.1.8"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.1.8.tgz#1d590429fe8187a02707720ecf38a6fe46ce294b"
-  integrity sha512-6XzyyNM9EKQW4HKuzbo/CkOIjn/evtCmsU+MUM1xDfJ+3/rNjBttM1NgN7AOQvN6tP1Sl1D1PIKMreTArnxM9A==
+"@types/node@>= 8", "@types/node@^13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.5.0.tgz#4e498dbf355795a611a87ae5ef811a8660d42662"
+  integrity sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -435,10 +435,10 @@
   dependencies:
     "@actions/github" "^2.0.1"
 
-"@technote-space/github-action-helper@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@technote-space/github-action-helper/-/github-action-helper-0.8.0.tgz#b500e82da50a92601ab140ab72bc82dbd4833004"
-  integrity sha512-t3SLKTQeS/WHCN47F3tMjt+rqs4j8wMi3dqPkUubuHs7TQo1kE1NPXgNRAZKesZHRUfkhE6ALZk7OIiabSGqcw==
+"@technote-space/github-action-helper@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@technote-space/github-action-helper/-/github-action-helper-0.8.1.tgz#cd419086827304fba9ea194b7c2937a53f9e9af9"
+  integrity sha512-BezxGoONFTukIVLHDVo1MYv6JOMcDii6lxGajeFUObvbngYMeBICROpCyVrlE8e6dw69qE3xefrZf/DlcGWghw==
   dependencies:
     "@actions/core" "^1.2.1"
     "@actions/github" "^2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1114,9 +1114,9 @@ cssom@~0.3.6:
   integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
 
 cssstyle@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.1.0.tgz#99f50a3aa21d4af16e758ae3e454dcf5940b9122"
-  integrity sha512-1iwCdymVYhMdQWiZ+9mB7x+urdNLPGTWsIZt6euFk8Yi+dOERK2ccoAUA3Bl8I5vmK5qfz/eLkBRyLbs42ov4A==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.2.0.tgz#e4c44debccd6b7911ed617a4395e5754bba59992"
+  integrity sha512-sEb3XFPx3jNnCAMtqrXPDeSgQr+jojtCeNf8cvMNMh1cG970+lljssvQDzPq6lmmJu2Vhqood/gtEomBiHOGnA==
   dependencies:
     cssom "~0.3.6"
 


### PR DESCRIPTION
## Base PullRequest

default branch (https://github.com/technote-space/github-action-pr-helper/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>npx npm-check-updates -u --packageFile package.json</em></summary>

```Shell
Upgrading /home/runner/work/github-action-pr-helper/github-action-pr-helper/package.json

All dependencies match the latest package versions :)
```

### stderr:

```Shell
npx: installed 259 in 16.415s
```

</details>
<details>
<summary><em>yarn install</em></summary>

```Shell
yarn install v1.21.1
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.1.2: The platform "linux" is incompatible with this module.
info "fsevents@2.1.2" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 15.66s.
```



</details>
<details>
<summary><em>yarn upgrade</em></summary>

```Shell
yarn upgrade v1.21.1
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.1.2: The platform "linux" is incompatible with this module.
info "fsevents@2.1.2" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 347 new dependencies.
info Direct dependencies
├─ @technote-space/filter-github-action@0.1.17
├─ @technote-space/github-action-helper@0.8.0
├─ @technote-space/github-action-test-helper@0.1.4
├─ @types/jest@24.9.0
├─ @types/node@13.1.8
├─ @typescript-eslint/eslint-plugin@2.17.0
├─ @typescript-eslint/parser@2.17.0
├─ eslint@6.8.0
├─ jest-circus@25.1.0
├─ jest@25.1.0
├─ moment@2.24.0
├─ nock@11.7.2
├─ ts-jest@25.0.0
└─ typescript@3.7.5
info All dependencies
├─ @babel/core@7.8.3
├─ @babel/helper-function-name@7.8.3
├─ @babel/helper-get-function-arity@7.8.3
├─ @babel/helper-split-export-declaration@7.8.3
├─ @babel/helpers@7.8.3
├─ @babel/highlight@7.8.3
├─ @babel/plugin-syntax-bigint@7.8.3
├─ @babel/plugin-syntax-object-rest-spread@7.8.3
├─ @bcoe/v8-coverage@0.2.3
├─ @cnakazawa/watch@1.0.3
├─ @istanbuljs/load-nyc-config@1.0.0
├─ @jest/reporters@25.1.0
├─ @jest/test-sequencer@25.1.0
├─ @octokit/auth-token@2.4.0
├─ @octokit/endpoint@5.5.1
├─ @octokit/graphql@4.3.1
├─ @octokit/request-error@1.2.0
├─ @octokit/request@5.3.1
├─ @octokit/rest@16.38.1
├─ @sinonjs/commons@1.7.0
├─ @technote-space/filter-github-action@0.1.17
├─ @technote-space/github-action-helper@0.8.0
├─ @technote-space/github-action-test-helper@0.1.4
├─ @types/babel__core@7.1.3
├─ @types/babel__generator@7.6.1
├─ @types/babel__template@7.0.2
├─ @types/babel__traverse@7.0.8
├─ @types/color-name@1.1.1
├─ @types/eslint-visitor-keys@1.0.0
├─ @types/istanbul-lib-coverage@2.0.1
├─ @types/istanbul-lib-report@3.0.0
├─ @types/jest@24.9.0
├─ @types/json-schema@7.0.4
├─ @types/node@13.1.8
├─ @types/stack-utils@1.0.1
├─ @typescript-eslint/eslint-plugin@2.17.0
├─ @typescript-eslint/parser@2.17.0
├─ acorn-globals@4.3.4
├─ acorn-jsx@5.1.0
├─ acorn-walk@6.2.0
├─ ajv@6.11.0
├─ ansi-regex@4.1.0
├─ anymatch@3.1.1
├─ argparse@1.0.10
├─ arr-flatten@1.1.0
├─ array-equal@1.0.0
├─ asn1@0.2.4
├─ assign-symbols@1.0.0
├─ asynckit@0.4.0
├─ atob-lite@2.0.0
├─ atob@2.1.2
├─ aws-sign2@0.7.0
├─ aws4@1.9.1
├─ babel-jest@25.1.0
├─ babel-plugin-jest-hoist@25.1.0
├─ babel-preset-jest@25.1.0
├─ balanced-match@1.0.0
├─ base@0.11.2
├─ bcrypt-pbkdf@1.0.2
├─ before-after-hook@2.1.0
├─ brace-expansion@1.1.11
├─ braces@3.0.2
├─ browser-process-hrtime@0.1.3
├─ browser-resolve@1.11.3
├─ bs-logger@0.2.6
├─ bser@2.1.1
├─ btoa-lite@1.0.0
├─ buffer-from@1.1.1
├─ cache-base@1.0.1
├─ capture-exit@2.0.0
├─ caseless@0.12.0
├─ chardet@0.7.0
├─ ci-info@2.0.0
├─ class-utils@0.3.6
├─ cli-cursor@3.1.0
├─ cli-width@2.2.0
├─ cliui@6.0.0
├─ collection-visit@1.0.0
├─ color-convert@2.0.1
├─ color-name@1.1.4
├─ combined-stream@1.0.8
├─ concat-map@0.0.1
├─ convert-source-map@1.7.0
├─ copy-descriptor@0.1.1
├─ core-util-is@1.0.2
├─ cross-spawn@6.0.5
├─ cssom@0.4.4
├─ cssstyle@2.2.0
├─ dashdash@1.14.1
├─ data-urls@1.1.0
├─ decode-uri-component@0.2.0
├─ deep-is@0.1.3
├─ delayed-stream@1.0.0
├─ detect-newline@3.1.0
├─ diff-sequences@25.1.0
├─ doctrine@3.0.0
├─ ecc-jsbn@0.1.2
├─ emoji-regex@8.0.0
├─ end-of-stream@1.4.4
├─ es-abstract@1.17.4
├─ es-to-primitive@1.2.1
├─ escodegen@1.13.0
├─ eslint@6.8.0
├─ espree@6.1.2
├─ esprima@4.0.1
├─ esquery@1.0.1
├─ esrecurse@4.2.1
├─ estraverse@4.3.0
├─ expand-brackets@2.1.4
├─ extend@3.0.2
├─ external-editor@3.1.0
├─ extglob@2.0.4
├─ extsprintf@1.3.0
├─ fast-deep-equal@3.1.1
├─ fast-levenshtein@2.0.6
├─ figures@3.1.0
├─ file-entry-cache@5.0.1
├─ fill-range@7.0.1
├─ flat-cache@2.0.1
├─ flatted@2.0.1
├─ for-in@1.0.2
├─ forever-agent@0.6.1
├─ form-data@2.3.3
├─ fs.realpath@1.0.0
├─ gensync@1.0.0-beta.1
├─ get-caller-file@2.0.5
├─ get-stream@4.1.0
├─ get-value@2.0.6
├─ getpass@0.1.7
├─ glob-parent@5.1.0
├─ glob@7.1.6
├─ globals@12.3.0
├─ growly@1.3.0
├─ har-schema@2.0.0
├─ har-validator@5.1.3
├─ has-value@1.0.0
├─ html-encoding-sniffer@1.0.2
├─ html-escaper@2.0.0
├─ http-signature@1.2.0
├─ human-signals@1.1.1
├─ iconv-lite@0.4.24
├─ ignore@4.0.6
├─ import-fresh@3.2.1
├─ inflight@1.0.6
├─ inherits@2.0.4
├─ inquirer@7.0.3
├─ ip-regex@2.1.0
├─ is-accessor-descriptor@1.0.0
├─ is-callable@1.1.5
├─ is-data-descriptor@1.0.0
├─ is-date-object@1.0.2
├─ is-descriptor@1.0.2
├─ is-extglob@2.1.1
├─ is-plain-object@2.0.4
├─ is-promise@2.1.0
├─ is-regex@1.0.5
├─ is-stream@1.1.0
├─ is-symbol@1.0.3
├─ is-typedarray@1.0.0
├─ is-windows@1.0.2
├─ is-wsl@2.1.1
├─ isarray@1.0.0
├─ isstream@0.1.2
├─ istanbul-lib-source-maps@4.0.0
├─ istanbul-reports@3.0.0
├─ jest-changed-files@25.1.0
├─ jest-circus@25.1.0
├─ jest-cli@25.1.0
├─ jest-docblock@25.1.0
├─ jest-environment-jsdom@25.1.0
├─ jest-environment-node@25.1.0
├─ jest-leak-detector@25.1.0
├─ jest-pnp-resolver@1.2.1
├─ jest-resolve-dependencies@25.1.0
├─ jest-serializer@25.1.0
├─ jest-watcher@25.1.0
├─ jest@25.1.0
├─ js-tokens@4.0.0
├─ jsdom@15.2.1
├─ jsesc@2.5.2
├─ json-schema-traverse@0.4.1
├─ json-schema@0.2.3
├─ json-stable-stringify-without-jsonify@1.0.1
├─ json-stringify-safe@5.0.1
├─ json5@2.1.1
├─ jsprim@1.4.1
├─ kind-of@3.2.2
├─ kleur@3.0.3
├─ leven@3.1.0
├─ levn@0.3.0
├─ locate-path@5.0.0
├─ lodash.get@4.4.2
├─ lodash.memoize@4.1.2
├─ lodash.set@4.3.2
├─ lodash.sortby@4.7.0
├─ lodash.uniq@4.5.0
├─ lolex@5.1.2
├─ macos-release@2.3.0
├─ make-dir@3.0.0
├─ make-error@1.3.5
├─ makeerror@1.0.11
├─ map-visit@1.0.0
├─ mime-db@1.43.0
├─ mime-types@2.1.26
├─ mimic-fn@2.1.0
├─ mixin-deep@1.3.2
├─ mkdirp@0.5.1
├─ moment@2.24.0
├─ ms@2.1.2
├─ mute-stream@0.0.8
├─ nanomatch@1.2.13
├─ nice-try@1.0.5
├─ nock@11.7.2
├─ node-fetch@2.6.0
├─ node-int64@0.4.0
├─ node-modules-regexp@1.0.0
├─ node-notifier@6.0.0
├─ normalize-path@3.0.0
├─ npm-run-path@2.0.2
├─ nwsapi@2.2.0
├─ oauth-sign@0.9.0
├─ object-copy@0.1.0
├─ object-inspect@1.7.0
├─ object-keys@1.1.1
├─ object.assign@4.1.0
├─ object.getownpropertydescriptors@2.1.0
├─ octokit-pagination-methods@1.1.0
├─ optionator@0.8.3
├─ os-name@3.1.0
├─ os-tmpdir@1.0.2
├─ p-each-series@2.1.0
├─ p-finally@1.0.0
├─ p-limit@2.2.2
├─ p-locate@4.1.0
├─ p-try@2.2.0
├─ parent-module@1.0.1
├─ parse5@5.1.0
├─ pascalcase@0.1.1
├─ path-exists@4.0.0
├─ path-is-absolute@1.0.1
├─ path-key@2.0.1
├─ path-parse@1.0.6
├─ performance-now@2.1.0
├─ picomatch@2.2.1
├─ pirates@4.0.1
├─ pkg-dir@4.2.0
├─ pn@1.1.0
├─ posix-character-classes@0.1.1
├─ progress@2.0.3
├─ prompts@2.3.0
├─ propagate@2.0.1
├─ psl@1.7.0
├─ qs@6.5.2
├─ react-is@16.12.0
├─ regexpp@2.0.1
├─ remove-trailing-separator@1.1.0
├─ repeat-element@1.1.3
├─ request-promise-core@1.1.3
├─ request-promise-native@1.0.8
├─ request@2.88.0
├─ require-directory@2.1.1
├─ require-main-filename@2.0.0
├─ resolve-cwd@3.0.0
├─ resolve-url@0.2.1
├─ resolve@1.15.0
├─ restore-cursor@3.1.0
├─ ret@0.1.15
├─ rimraf@3.0.0
├─ rsvp@4.8.5
├─ run-async@2.3.0
├─ rxjs@6.5.4
├─ safe-buffer@5.2.0
├─ safer-buffer@2.1.2
├─ sane@4.1.0
├─ saxes@3.1.11
├─ semver@6.3.0
├─ set-blocking@2.0.0
├─ set-value@2.0.1
├─ shebang-command@1.2.0
├─ shebang-regex@1.0.0
├─ shell-escape@0.2.0
├─ shellwords@0.1.1
├─ sisteransi@1.0.4
├─ slice-ansi@2.1.0
├─ snapdragon-node@2.1.1
├─ snapdragon-util@3.0.1
├─ source-map-resolve@0.5.3
├─ source-map-support@0.5.16
├─ source-map-url@0.4.0
├─ source-map@0.6.1
├─ split-string@3.1.0
├─ sprintf-js@1.1.2
├─ sshpk@1.16.1
├─ static-extend@0.1.2
├─ stealthy-require@1.1.1
├─ string.prototype.trimleft@2.1.1
├─ string.prototype.trimright@2.1.1
├─ strip-bom@4.0.0
├─ strip-eof@1.0.0
├─ strip-final-newline@2.0.0
├─ strip-json-comments@3.0.1
├─ supports-hyperlinks@2.0.0
├─ symbol-tree@3.2.4
├─ table@5.4.6
├─ terminal-link@2.1.1
├─ test-exclude@6.0.0
├─ text-table@0.2.0
├─ through@2.3.8
├─ tmp@0.0.33
├─ to-fast-properties@2.0.0
├─ to-object-path@0.3.0
├─ to-regex-range@5.0.1
├─ tough-cookie@3.0.1
├─ tr46@1.0.1
├─ ts-jest@25.0.0
├─ tslib@1.10.0
├─ tunnel-agent@0.6.0
├─ tweetnacl@0.14.5
├─ type-detect@4.0.8
├─ typedarray-to-buffer@3.1.5
├─ typescript@3.7.5
├─ union-value@1.0.1
├─ unset-value@1.0.0
├─ uri-js@4.2.2
├─ urix@0.1.0
├─ use@3.1.1
├─ util.promisify@1.0.1
├─ uuid@3.4.0
├─ v8-compile-cache@2.1.0
├─ v8-to-istanbul@4.0.1
├─ verror@1.10.0
├─ w3c-hr-time@1.0.1
├─ w3c-xmlserializer@1.1.2
├─ walker@1.0.7
├─ whatwg-encoding@1.0.5
├─ whatwg-mimetype@2.3.0
├─ which-module@2.0.0
├─ which@1.3.1
├─ windows-release@3.2.0
├─ word-wrap@1.2.3
├─ wrap-ansi@6.2.0
├─ write-file-atomic@3.0.1
├─ write@1.0.3
├─ ws@7.2.1
├─ xmlchars@2.2.0
├─ y18n@4.0.0
└─ yargs-parser@10.1.0
Done in 5.08s.
```



</details>
<details>
<summary><em>yarn audit</em></summary>

```Shell
yarn audit v1.21.1
0 vulnerabilities found - Packages audited: 1221908
Done in 1.18s.
```



</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)